### PR TITLE
Update alias.txt Add EDDK SID Fix Alias

### DIFF
--- a/EDGG/Alias/alias.txt
+++ b/EDGG/Alias/alias.txt
@@ -45,6 +45,7 @@
 .wallcoc .wallop $aircraft unable to comply with ATC instructions (CoC B8).
 .wallnoco .wallop $aircraft not in contact with anyone and ignoring contact me messages (CoC B3).
 .wallemer .wallop $aircraft not cancelling their emergency despite having been instructed to do so (CoC B6).
+.eddkfix There is an issue with the EDDK SIDs in the City-Update Scenery, so please check out vats.im/eddkfix to fix.
 
 ;*** --- GROUND --- ***
 .p Pushback approved.


### PR DESCRIPTION
There is still the issue with IniBuilds scenery not being updated in EDDK, resulting in aircraft using the default database not having SIDs for the 13/31 RWYs. There is a short link to the article in the knowledgebase, but a short alias for this issue would be great as Microsoft is not fixing the problem. So the Alis would be helbfull for the next months until it got fixed. But there is no "need" for it, but it would be a nice to have. :-) Greetings Tobias