### PR TITLE
TopSky settings update

### DIFF
--- a/EDGG/Plugins/Topsky_EDGG/TopSkySettings.txt
+++ b/EDGG/Plugins/Topsky_EDGG/TopSkySettings.txt
@@ -268,8 +268,8 @@ System_FIC_Position_Free_Filtered=1
 
 System_UseAcceptedCoordColor=1
 System_UseRwyLockedColor=1
-System_UseSidStarAllocationColor=0
-//System_UseSidStarNoAllocationColor=0
+System_UseSidAllocationColor=0
+System_UseStarAllocationColor=0
 
 Track_HistoryDots=5
 Track_PredictionLine=0

--- a/EDGG/Plugins/Topsky_EDUU/TopSkySettings.txt
+++ b/EDGG/Plugins/Topsky_EDUU/TopSkySettings.txt
@@ -243,8 +243,8 @@ System_UseAUP=1
 
 System_UseAcceptedCoordColor=1
 System_UseRwyLockedColor=0
-System_UseSidStarAllocationColor=0
-//System_UseSidStarNoAllocationColor=0
+System_UseSidAllocationColor=0
+System_UseStarAllocationColor=0
 
 Track_HistoryDots=5
 Track_PredictionLine=0

--- a/EDGG/Plugins/Topsky_EDYY/TopSkySettings.txt
+++ b/EDGG/Plugins/Topsky_EDYY/TopSkySettings.txt
@@ -269,8 +269,8 @@ System_ProxySounds=0
 System_UseAUP=1
 System_UseAcceptedCoordColor=1
 System_UseRwyLockedColor=0
-System_UseSidStarAllocationColor=0
-//System_UseSidStarNoAllocationColor=0
+System_UseSidAllocationColor=0
+System_UseStarAllocationColor=0
 
 Track_HistoryDots=5
 Track_PredictionLine=0


### PR DESCRIPTION
System_UseSidStarAllocationColor setting removed in b14, replaced by separate settings for SID and STAR, updated accordingly to prevent error message and incorrect STAR color