### PR TITLE
EDDF - Map Font

### DIFF
--- a/EDGG/Plugins/GRP/Phoenix/GRpluginSettings.txt
+++ b/EDGG/Plugins/GRP/Phoenix/GRpluginSettings.txt
@@ -195,6 +195,7 @@ Airport_Runway_Closed_Dep=25R
 Airport_Runway_Closed_Dep=07L
 Window_APP_AltFilter=10000
 System_RIM=0
+Maps_Font=Lucida Sans Unicode
 
 [EDDL]
 Airport_Runway_Area_LVP=23L:90


### PR DESCRIPTION
Die Map Font weicht (in Frankfurt) im Gegensatz zum echten Leben, im GRP ein bisschen ab, diese PR fixt dieses Problem. (Referenz Mittendrin FRA Flughafen Staffel 14 Folge 4, Minute 12:41)