### PR TITLE
Automatically enable VATSIM Radar's VATGlasses Feature via Link

### DIFF
--- a/EDGG/Settings/ALL/EDGG_Profile.txt
+++ b/EDGG/Settings/ALL/EDGG_Profile.txt
@@ -21,17 +21,17 @@ ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDDL_APP:150:5
 ATIS2:Langen Radar
-ATIS3:Coverage at vatsim-radar.com - PDC/DCL Datalink [EDDL]
+ATIS3:Coverage at vatsim-radar.com/vg - PDC/DCL Datalink [EDDL]
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDDL_DEP:150:5
 ATIS2:Langen Radar
-ATIS3:Coverage at vatsim-radar.com - PDC/DCL Datalink [EDDL]
+ATIS3:Coverage at vatsim-radar.com/vg - PDC/DCL Datalink [EDDL]
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDDL_BOT_APP:150:5
 ATIS2:Langen Radar
-ATIS3:Coverage at vatsim-radar.com - PDC/DCL Datalink [EDDL]
+ATIS3:Coverage at vatsim-radar.com/vg - PDC/DCL Datalink [EDDL]
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDDL_F_APP:150:5
@@ -41,12 +41,12 @@ ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDDS_STG_APP:150:5
 ATIS2:Langen Radar
-ATIS3:Coverage at vatsim-radar.com - PDC/DCL Datalink [EDDS]
+ATIS3:Coverage at vatsim-radar.com/vg - PDC/DCL Datalink [EDDS]
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDDS_REU_APP:150:5
 ATIS2:Langen Radar
-ATIS3:Coverage at vatsim-radar.com - PDC/DCL Datalink [EDDS]
+ATIS3:Coverage at vatsim-radar.com/vg - PDC/DCL Datalink [EDDS]
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDDS_F_APP:150:5
@@ -56,12 +56,12 @@ ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDDK_APP:150:5
 ATIS2:Langen Radar
-ATIS3:Coverage at vatsim-radar.com - PDC/DCL Datalink [EDDK]
+ATIS3:Coverage at vatsim-radar.com/vg - PDC/DCL Datalink [EDDK]
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDDK_NOR_APP:150:5
 ATIS2:Langen Radar
-ATIS3:Coverage at vatsim-radar.com - PDC/DCL Datalink [EDDK]
+ATIS3:Coverage at vatsim-radar.com/vg - PDC/DCL Datalink [EDDK]
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDDK_F_APP:150:5
@@ -71,67 +71,67 @@ ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDFH_EIF_APP:150:5
 ATIS2:Langen Radar
-ATIS3:Coverage at vatsim-radar.com - PDC/DCL Datalink [EDFH]
+ATIS3:Coverage at vatsim-radar.com/vg - PDC/DCL Datalink [EDFH]
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDDR_PFA_APP:150:5
 ATIS2:Langen Radar
-ATIS3:Coverage at vatsim-radar.com - PDC/DCL Datalink [EDDR]
+ATIS3:Coverage at vatsim-radar.com/vg - PDC/DCL Datalink [EDDR]
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDFM_NKL_APP:150:5
 ATIS2:Langen Radar
-ATIS3:Coverage at vatsim-radar.com - PDC/DCL Datalink [EDFM]
+ATIS3:Coverage at vatsim-radar.com/vg - PDC/DCL Datalink [EDFM]
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDDG_HMM_APP:150:5
 ATIS2:Langen Radar
-ATIS3:Coverage at vatsim-radar.com - PDC/DCL Datalink [EDDG]
+ATIS3:Coverage at vatsim-radar.com/vg - PDC/DCL Datalink [EDDG]
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDLP_PAL_APP:150:5
 ATIS2:Langen Radar
-ATIS3:Coverage at vatsim-radar.com - PDC/DCL Datalink [EDLP]
+ATIS3:Coverage at vatsim-radar.com/vg - PDC/DCL Datalink [EDLP]
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDGG_BAD_CTR:300:6
 ATIS2:Langen Radar - NO CPDLC
-ATIS3:Coverage at vatsim-radar.com - only below FL245
+ATIS3:Coverage at vatsim-radar.com/vg - only below FL245
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDGG_DKB_CTR:300:6
 ATIS2:Langen Radar - CPDLC [EDGD]
-ATIS3:Coverage at vatsim-radar.com
+ATIS3:Coverage at vatsim-radar.com/vg
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDGG_GIN_CTR:300:6
 ATIS2:Langen Radar - CPDLC [EDGG]
-ATIS3:Coverage at vatsim-radar.com
+ATIS3:Coverage at vatsim-radar.com/vg
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDGG_KTG_CTR:300:6
 ATIS2:Langen Radar - CPDLC [EDGK]
-ATIS3:Coverage at vatsim-radar.com
+ATIS3:Coverage at vatsim-radar.com/vg
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDGG_PAH_CTR:300:6
 ATIS2:Langen Radar - CPDLC [EDGP]
-ATIS3:Coverage at vatsim-radar.com
+ATIS3:Coverage at vatsim-radar.com/vg
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDGG_RUD_CTR:300:6
 ATIS2:Langen Radar - NO CPDLC
-ATIS3:Coverage at vatsim-radar.com - only below FL245
+ATIS3:Coverage at vatsim-radar.com/vg - only below FL245
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDGG_HEF_CTR:300:6
 ATIS2:Langen Radar - NO CPDLC
-ATIS3:Coverage at vatsim-radar.com - only below FL245
+ATIS3:Coverage at vatsim-radar.com/vg - only below FL245
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDGG_HAB_CTR:300:6
 ATIS2:Langen Radar - NO CPDLC
-ATIS3:Coverage at vatsim-radar.com - only below FL245
+ATIS3:Coverage at vatsim-radar.com/vg - only below FL245
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 END

--- a/EDGG/Settings/ALL/EDUU_Profile.txt
+++ b/EDGG/Settings/ALL/EDUU_Profile.txt
@@ -6,32 +6,32 @@ ATIS4:
 
 PROFILE:EDUU_WUR_CTR:300:6
 ATIS2:Rhein Radar - CPDLC [EDUW]
-ATIS3:Coverage at vatsim-radar.com - only above FL245!
+ATIS3:Coverage at vatsim-radar.com/vg - only above FL245!
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDUU_NTM_CTR:300:6
 ATIS2:Rhein Radar - CPDLC [EDUN]
-ATIS3:Coverage at vatsim-radar.com - only above FL245!
+ATIS3:Coverage at vatsim-radar.com/vg - only above FL245!
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDUU_FFM_CTR:300:6
 ATIS2:Rhein Radar - CPDLC [EDUF]
-ATIS3:Coverage at vatsim-radar.com - only above FL245!
+ATIS3:Coverage at vatsim-radar.com/vg - only above FL245!
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDUU_FUL_CTR:300:6
 ATIS2:Rhein Radar - CPDLC [EDUU]
-ATIS3:Coverage at vatsim-radar.com - only above FL245!
+ATIS3:Coverage at vatsim-radar.com/vg - only above FL245!
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDUU_SLN_CTR:300:6
 ATIS2:Rhein Radar - CPDLC [EDUS]
-ATIS3:Coverage at vatsim-radar.com - only above FL245!
+ATIS3:Coverage at vatsim-radar.com/vg - only above FL245!
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDUU_TGO_CTR:300:6
 ATIS2:Rhein Radar - CPDLC [EDUT]
-ATIS3:Coverage at vatsim-radar.com - only above FL245!
+ATIS3:Coverage at vatsim-radar.com/vg - only above FL245!
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 END

--- a/EDGG/Settings/ALL/EDYY_Profile.txt
+++ b/EDGG/Settings/ALL/EDYY_Profile.txt
@@ -6,42 +6,42 @@ ATIS4:
 
 PROFILE:EDYY_ML_CTR:450:6
 ATIS2:Maastricht Radar - CPDLC [EDYM]
-ATIS3:Coverage at vatsim-radar.com - only above FL245!
+ATIS3:Coverage at vatsim-radar.com/vg - only above FL245!
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDYY_MH_CTR:450:6
 ATIS2:Maastricht Radar - CPDLC [EDNH]
-ATIS3:Coverage at vatsim-radar.com - only above FL245!
+ATIS3:Coverage at vatsim-radar.com/vg - only above FL245!
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDYY_RL_CTR:450:6
 ATIS2:Maastricht Radar - CPDLC [EDYR]
-ATIS3:Coverage at vatsim-radar.com - only above FL245!
+ATIS3:Coverage at vatsim-radar.com/vg - only above FL245!
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDYY_RH_CTR:450:6
 ATIS2:Maastricht Radar - CPDLC [EDRH]
-ATIS3:Coverage at vatsim-radar.com - only above FL245!
+ATIS3:Coverage at vatsim-radar.com/vg - only above FL245!
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDYY_SL_CTR:450:6
 ATIS2:Maastricht Radar - CPDLC [EDYS]
-ATIS3:Coverage at vatsim-radar.com - only above FL245!
+ATIS3:Coverage at vatsim-radar.com/vg - only above FL245!
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDYY_SH_CTR:450:6
 ATIS2:Maastricht Radar - CPDLC [EDSH]
-ATIS3:Coverage at vatsim-radar.com - only above FL245!
+ATIS3:Coverage at vatsim-radar.com/vg - only above FL245!
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDYY_CL_CTR:450:6
 ATIS2:Maastricht Radar - CPDLC [EDYC]
-ATIS3:Coverage at vatsim-radar.com - only above FL245!
+ATIS3:Coverage at vatsim-radar.com/vg - only above FL245!
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 PROFILE:EDYY_CH_CTR:450:6
 ATIS2:Maastricht Radar - CPDLC [EDCH]
-ATIS3:Coverage at vatsim-radar.com - only above FL245!
+ATIS3:Coverage at vatsim-radar.com/vg - only above FL245!
 ATIS4:You have feedback? Submit it! feedback.vatger.de
 
 END


### PR DESCRIPTION
Should be self explanatory, added /vg to automatically enable VATGlasses